### PR TITLE
release: SSR localization for crawler-visible content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "craftscript",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check ./",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:ssr-localization": "vitest run src/i18n/ssr-localization.test.ts",
     "test:release-version": "node --test ci/check-version-bump.test.mjs",
     "check:release-version": "node ci/check-version-bump.mjs"
   },

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -13,7 +13,10 @@ export function generateStaticParams() {
   return SUPPORTED_LOCALES.map((locale) => ({ locale }));
 }
 
-const LocaleLayout: React.FC<ILocaleLayoutProps> = ({ children, params }) => {
+const LocaleLayout: React.FC<ILocaleLayoutProps> = async ({
+  children,
+  params,
+}) => {
   if (!isLocaleSlug(params.locale)) {
     notFound();
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import {
   LOCALE_HTML_LANG,
 } from '@src/i18n/locales';
 import { SITE_URL } from '@src/i18n/routes';
+import { getServerI18nState } from '@src/i18n/server';
 
 import 'react-toastify/dist/ReactToastify.min.css';
 import '@vodis/cs-foundation/styles/tokens.css';
@@ -57,9 +58,12 @@ const neueHaasGrot = localFont({
   ],
 });
 
-const RootLayout: React.FC<PropsWithChildren> = ({ children }) => {
+const RootLayout: React.FC<PropsWithChildren> = async ({ children }) => {
   const localeHeader = headers().get('x-cs-locale') ?? DEFAULT_LOCALE;
   const locale = isLocaleSlug(localeHeader) ? localeHeader : DEFAULT_LOCALE;
+  const preloadedState = {
+    i18n: await getServerI18nState(locale),
+  };
 
   return (
     <html lang={LOCALE_HTML_LANG[locale]}>
@@ -73,7 +77,7 @@ const RootLayout: React.FC<PropsWithChildren> = ({ children }) => {
       >
         <GoogleAnalytics />
         <main className="h-full flex flex-1 flex-col bg-black">
-          <Providers>
+          <Providers preloadedState={preloadedState}>
             <Header>
               <Menu />
             </Header>

--- a/src/i18n/default-translations.test.ts
+++ b/src/i18n/default-translations.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { defaultTranslations } from '@src/stores/reducers/i18n/default';
+
+const SRC_DIR = join(process.cwd(), 'src');
+const TRANSLATION_KEY_PATTERN = /Texts\.[A-Za-z0-9-]+/g;
+
+describe('default translations', () => {
+  it('cover every translation key referenced in source files', () => {
+    expect(collectMissingTranslationKeys(SRC_DIR, defaultTranslations)).toEqual(
+      [],
+    );
+  });
+
+  it('passes when mocked source keys exist in provided translations', () => {
+    const missingKeys = collectMissingTranslationKeys(
+      '/mock-src',
+      {
+        'Texts.side-menu-home': 'Home',
+        'Texts.content-about-title': 'About CraftScript',
+      },
+      {
+        readDirectory: (directory) =>
+          directory === '/mock-src' ? ['page.tsx'] : [],
+        readFile: () =>
+          [
+            "translate(translations, 'Texts.side-menu-home')",
+            "translate(translations, 'Texts.content-about-title')",
+          ].join('\n'),
+        isDirectory: () => false,
+        joinPath: (...parts) => parts.join('/'),
+      },
+    );
+
+    expect(missingKeys).toEqual([]);
+  });
+
+  it('reports mocked source keys missing from provided translations', () => {
+    const missingKeys = collectMissingTranslationKeys(
+      '/mock-src',
+      {
+        'Texts.side-menu-home': 'Home',
+      },
+      {
+        readDirectory: (directory) =>
+          directory === '/mock-src' ? ['page.tsx'] : [],
+        readFile: () =>
+          [
+            "translate(translations, 'Texts.side-menu-home')",
+            "translate(translations, 'Texts.content-about-title')",
+          ].join('\n'),
+        isDirectory: () => false,
+        joinPath: (...parts) => parts.join('/'),
+      },
+    );
+
+    expect(missingKeys).toEqual(['Texts.content-about-title']);
+  });
+});
+
+interface IFileSystemReader {
+  readDirectory: (directory: string) => string[];
+  readFile: (filePath: string) => string;
+  isDirectory: (filePath: string) => boolean;
+  joinPath: (...parts: string[]) => string;
+}
+
+function collectMissingTranslationKeys(
+  sourceDirectory: string,
+  translations: Record<string, string>,
+  fileSystem: IFileSystemReader = nodeFileSystem,
+): string[] {
+  const usedKeys = new Set<string>();
+
+  for (const filePath of walkFiles(sourceDirectory, fileSystem)) {
+    if (!/\.(ts|tsx)$/.test(filePath) || filePath.endsWith('.test.ts')) {
+      continue;
+    }
+
+    const source = fileSystem.readFile(filePath);
+    const matches = source.matchAll(TRANSLATION_KEY_PATTERN);
+
+    for (const match of matches) {
+      usedKeys.add(match[0]);
+    }
+  }
+
+  return [...usedKeys].filter((key) => !translations[key]);
+}
+
+const nodeFileSystem: IFileSystemReader = {
+  readDirectory: readdirSync,
+  readFile: (filePath) => readFileSync(filePath, 'utf8'),
+  isDirectory: (filePath) => statSync(filePath).isDirectory(),
+  joinPath: join,
+};
+
+function walkFiles(
+  directory: string,
+  fileSystem: IFileSystemReader = nodeFileSystem,
+): string[] {
+  return fileSystem.readDirectory(directory).flatMap((entry) => {
+    const filePath = fileSystem.joinPath(directory, entry);
+
+    return fileSystem.isDirectory(filePath)
+      ? walkFiles(filePath, fileSystem)
+      : filePath;
+  });
+}

--- a/src/i18n/routes.ts
+++ b/src/i18n/routes.ts
@@ -2,15 +2,14 @@ import type { Metadata } from 'next';
 
 import { translate } from '@src/i18n/translate';
 import { defaultTranslations } from '@src/stores/reducers/i18n/default';
-import type { ITranslationItem } from '@src/types/entities/language';
 import {
   DEFAULT_LOCALE,
   LOCALE_HTML_LANG,
   SUPPORTED_LOCALES,
   type LocaleSlug,
-  localeToLanguage,
   withLocalePath,
 } from '@src/i18n/locales';
+import { getServerTranslations } from '@src/i18n/server';
 
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || 'https://craftscript.com';
@@ -83,7 +82,7 @@ async function getRouteMetadata(pathname: string, locale: LocaleSlug) {
   const translationKeys =
     ROUTE_METADATA_TRANSLATION_KEYS[pathname] ??
     ROUTE_METADATA_TRANSLATION_KEYS['/'];
-  const translations = await getMetadataTranslations(locale);
+  const translations = await getServerTranslations(locale);
 
   return {
     title: translate(
@@ -97,33 +96,4 @@ async function getRouteMetadata(pathname: string, locale: LocaleSlug) {
       translate(defaultTranslations, translationKeys.description),
     ),
   };
-}
-
-async function getMetadataTranslations(
-  locale: LocaleSlug,
-): Promise<ITranslationItem> {
-  if (!API_BASE_URL) {
-    return {};
-  }
-
-  try {
-    const response = await fetch(
-      new URL(`api/v1/translations/${localeToLanguage(locale)}`, API_BASE_URL),
-      {
-        next: {
-          revalidate: 3600,
-        },
-      },
-    );
-
-    if (!response.ok) {
-      return {};
-    }
-
-    const language = await response.json();
-
-    return language.translations ?? {};
-  } catch {
-    return {};
-  }
 }

--- a/src/i18n/server.test.ts
+++ b/src/i18n/server.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('server i18n utilities', () => {
+  const originalApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.example.test';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = originalApiBaseUrl;
+    vi.restoreAllMocks();
+  });
+
+  it('builds a locale-specific Redux state from server translations', async () => {
+    const fetchMock = vi.fn(
+      async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        expect(String(url)).toBe(
+          'https://api.example.test/api/v1/translations/UA',
+        );
+        expect(init?.next?.revalidate).toBe(3600);
+
+        return new Response(
+          JSON.stringify({
+            languages: {
+              UA: {
+                language: 'Ukrainian',
+                title: 'UA',
+              },
+            },
+            translations: {
+              'Texts.content-about-paragraph-1': 'Translated paragraph',
+            },
+          }),
+        );
+      },
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getServerI18nState } = await import('./server');
+    const i18nState = await getServerI18nState('ua');
+
+    expect(i18nState.activeLanguage).toBe('UA');
+    expect(i18nState.languages.UA.language).toBe('Ukrainian');
+    expect(i18nState.translations['Texts.content-about-paragraph-1']).toBe(
+      'Translated paragraph',
+    );
+    expect(i18nState.translations['Texts.animate-label-home']).toBe(
+      'Unlock your potential',
+    );
+  });
+});

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -1,0 +1,68 @@
+import {
+  defaultLanguages,
+  defaultTranslations,
+} from '@src/stores/reducers/i18n/default';
+import type { II18nState } from '@src/stores/reducers/i18n/reducer';
+import type { ILanguage, ITranslationItem } from '@src/types/entities/language';
+import { localeToLanguage, type LocaleSlug } from '@src/i18n/locales';
+
+export async function getServerI18nState(
+  locale: LocaleSlug,
+): Promise<II18nState> {
+  const activeLanguage = localeToLanguage(locale);
+  const language = await getServerLanguage(activeLanguage);
+
+  return {
+    activeLanguage,
+    languages: language.languages ?? defaultLanguages,
+    translations: {
+      ...defaultTranslations,
+      ...(language.translations ?? {}),
+    },
+  };
+}
+
+export async function getServerTranslations(
+  locale: LocaleSlug,
+): Promise<ITranslationItem> {
+  const i18nState = await getServerI18nState(locale);
+
+  return i18nState.translations;
+}
+
+async function getServerLanguage(activeLanguage: string): Promise<ILanguage> {
+  if (!process.env.NEXT_PUBLIC_API_BASE_URL) {
+    return {
+      languages: defaultLanguages,
+      translations: defaultTranslations,
+    };
+  }
+
+  try {
+    const response = await fetch(
+      new URL(
+        `api/v1/translations/${activeLanguage}`,
+        process.env.NEXT_PUBLIC_API_BASE_URL,
+      ),
+      {
+        next: {
+          revalidate: 3600,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      return {
+        languages: defaultLanguages,
+        translations: defaultTranslations,
+      };
+    }
+
+    return response.json();
+  } catch {
+    return {
+      languages: defaultLanguages,
+      translations: defaultTranslations,
+    };
+  }
+}

--- a/src/i18n/ssr-localization.test.ts
+++ b/src/i18n/ssr-localization.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import { spawn } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { once } from 'node:events';
+
+const translatedValues = {
+  UA: {
+    htmlLang: 'uk',
+    path: '/ua/about',
+    aboutTitle: 'UA SSR About Title',
+    aboutParagraph: 'UA SSR localized about paragraph',
+    menuHome: 'UA SSR Home',
+  },
+  PT: {
+    htmlLang: 'pt',
+    path: '/pt/about',
+    aboutTitle: 'PT SSR About Title',
+    aboutParagraph: 'PT SSR localized about paragraph',
+    menuHome: 'PT SSR Home',
+  },
+};
+
+describe('SSR localization', () => {
+  it('exposes translated content in localized route initial HTML', async () => {
+    const api = await startMockTranslationsApi();
+    const appPort = await getFreePort();
+    const env = {
+      ...process.env,
+      NEXT_PUBLIC_API_BASE_URL: api.url,
+      NEXT_PUBLIC_SITE_URL: `http://127.0.0.1:${appPort}`,
+    };
+
+    await runCommand('pnpm', ['exec', 'next', 'build'], env);
+
+    const app = spawn(
+      'pnpm',
+      ['exec', 'next', 'start', '-p', String(appPort)],
+      {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    try {
+      await waitForHttp(`http://127.0.0.1:${appPort}/health`);
+
+      for (const expected of Object.values(translatedValues)) {
+        const html = await fetchText(
+          `http://127.0.0.1:${appPort}${expected.path}`,
+        );
+
+        expect(html).toMatch(
+          new RegExp(`<html[^>]*lang="${expected.htmlLang}"`),
+        );
+        expect(html).toMatch(new RegExp(expected.aboutTitle));
+        expect(html).toMatch(new RegExp(expected.aboutParagraph));
+        expect(html).toMatch(new RegExp(expected.menuHome));
+        expect(html).not.toMatch(/>\s*Texts\.[^<]*</);
+      }
+    } finally {
+      app.kill();
+      api.server.close();
+    }
+  }, 90_000);
+});
+
+interface IMockTranslationsApi {
+  server: Server;
+  url: string;
+}
+
+async function startMockTranslationsApi(): Promise<IMockTranslationsApi> {
+  const server = createServer((request, response) => {
+    const language = request.url?.split('/').pop();
+
+    if (!isTranslatedLanguage(language)) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+
+    const values = translatedValues[language];
+
+    response.writeHead(200, {
+      'content-type': 'application/json',
+    });
+    response.end(
+      JSON.stringify({
+        languages: {
+          [language]: {
+            language,
+            title: language,
+          },
+        },
+        translations: {
+          'Texts.animate-label-about': values.aboutTitle,
+          'Texts.side-menu-home': values.menuHome,
+          'Texts.content-about-title': values.aboutTitle,
+          'Texts.content-about-paragraph-1': values.aboutParagraph,
+          'Texts.content-about-paragraph-2': `${language} SSR localized second paragraph`,
+          'Texts.content-about-paragraph-3': `${language} SSR localized third paragraph`,
+          'Texts.panels-text-about': `${language} SSR Panel`,
+          'Texts.metadata-about-title': `${language} SSR Metadata Title`,
+          'Texts.metadata-about-description': `${language} SSR Metadata Description`,
+        },
+      }),
+    );
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  expect(address && typeof address === 'object').toBe(true);
+
+  if (!address || typeof address !== 'object') {
+    throw new Error('Mock translations API did not bind a TCP port');
+  }
+
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  expect(address && typeof address === 'object').toBe(true);
+
+  if (!address || typeof address !== 'object') {
+    throw new Error('Temporary server did not bind a TCP port');
+  }
+
+  const { port } = address;
+
+  server.close();
+  await once(server, 'close');
+
+  return port;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const child = spawn(command, args, {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+
+  child.stdout.on('data', (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    output += chunk;
+  });
+
+  const [code] = await once(child, 'exit');
+
+  expect(code, output).toBe(0);
+}
+
+async function waitForHttp(url: string): Promise<void> {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      await delay(500);
+    }
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url);
+  expect(response.status).toBe(200);
+
+  return response.text();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTranslatedLanguage(
+  language: string | undefined,
+): language is keyof typeof translatedValues {
+  return language !== undefined && language in translatedValues;
+}

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { Provider as StoreProvider } from 'react-redux';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -10,13 +10,25 @@ import LanguageProvider from '@src/providers/language/provider';
 
 import '@src/api/api';
 
-export const Store = createStore();
-export const QueryClient = queryClient();
+interface IProvidersProps extends React.PropsWithChildren {
+  preloadedState?: AppState;
+}
 
-const Providers = ({ children }: React.PropsWithChildren) => {
+const Providers = ({ children, preloadedState }: IProvidersProps) => {
+  const storeRef = useRef<ReturnType<typeof createStore>>();
+  const queryClientRef = useRef<ReturnType<typeof queryClient>>();
+
+  if (!storeRef.current) {
+    storeRef.current = createStore(preloadedState);
+  }
+
+  if (!queryClientRef.current) {
+    queryClientRef.current = queryClient();
+  }
+
   return (
-    <StoreProvider store={Store}>
-      <QueryClientProvider client={QueryClient}>
+    <StoreProvider store={storeRef.current}>
+      <QueryClientProvider client={queryClientRef.current}>
         <ReactQueryDevtools initialIsOpen={false} />
         <LanguageProvider>{children}</LanguageProvider>
       </QueryClientProvider>

--- a/src/stores/reducers/i18n/default.ts
+++ b/src/stores/reducers/i18n/default.ts
@@ -1,3 +1,10 @@
+export const defaultLanguages = {
+  EN: {
+    language: 'English',
+    title: 'EN',
+  },
+};
+
 export const defaultTranslations = {
   'Texts.panels-text-home': 'Vision',
   'Texts.animate-text-home-part-1': 'Technology led brands',
@@ -7,15 +14,94 @@ export const defaultTranslations = {
   'Texts.launch-app': 'Launch App',
   'Texts.side-menu-home': 'Home',
   'Texts.side-menu-products': 'Products',
+  'Texts.side-menu-ai': 'AI',
+  'Texts.side-menu-about': 'About',
+  'Texts.side-menu-docs': 'Docs',
   'Texts.animate-label-home': 'Unlock your potential',
+  'Texts.animate-label-about': 'About CraftScript',
+  'Texts.animate-label-ai': 'AI symbiosis',
+  'Texts.animate-label-use-cases': 'Real use cases',
+  'Texts.animate-text-use-cases-product-0-part-1': 'Investing and trading',
+  'Texts.animate-text-use-cases-product-0-part-2': 'for alternative assets',
+  'Texts.animate-text-use-cases-product-0-part-3': 'with digital ownership',
+  'Texts.animate-text-use-cases-product-0-part-4':
+    'and compliant market access.',
+  'Texts.animate-text-use-cases-product-1-part-1': 'Composable leverage',
+  'Texts.animate-text-use-cases-product-1-part-2': 'and lending workflows',
+  'Texts.animate-text-use-cases-product-1-part-3': 'for DeFi markets.',
+  'Texts.animate-text-use-cases-product-2-part-1': 'Decentralized coverage',
+  'Texts.animate-text-use-cases-product-2-part-2': 'for protocol risk',
+  'Texts.animate-text-use-cases-product-2-part-3': 'with transparent claims',
+  'Texts.animate-text-use-cases-product-2-part-4': 'and community governance',
+  'Texts.animate-text-use-cases-product-2-part-5': 'built for BridgeMutual.',
   'Texts.panels-text-about': 'Craft',
+  'Texts.panels-text-ai': 'AI',
+  'Texts.panels-text-use-cases': 'Cases',
   'Texts.header-put-through': 'Get in touch',
   'Texts.not-found-page': 'This page could not be found',
   'Texts.bread-crumbs-label-home': 'Home',
   'Texts.bread-crumbs-label-about': 'About CraftScript',
   'Texts.bread-crumbs-label-cases': 'Real use cases',
+  'Texts.bread-crumbs-label-ai': 'AI',
   'Texts.bread-crumbs-label-developers': 'Developers',
   'Texts.bread-crumbs-label-community': 'Community',
+  'Texts.content-about-title': 'About CraftScript',
+  'Texts.content-about-paragraph-1':
+    'CraftScript is a digital engineering company building practical products for Web3, AI, and data-driven business models.',
+  'Texts.content-about-paragraph-2':
+    'We help teams turn complex technology into reliable software, from early product discovery through production delivery.',
+  'Texts.content-about-paragraph-3':
+    'Our work focuses on privacy, transparency, automation, and long-term systems that can evolve with the market.',
+  'Texts.content-ai-title': 'AI symbiosis',
+  'Texts.content-ai-paragraph-1':
+    'We design AI-assisted systems that support people in research, content operations, analytics, and decision making.',
+  'Texts.content-ai-paragraph-2':
+    'Our approach combines domain knowledge with automation so teams can move faster without losing control of quality.',
+  'Texts.content-ai-paragraph-3':
+    'The result is software that improves workflows, reduces repetitive work, and keeps human judgment in the loop.',
+  'Texts.content-solutions-title': 'Solutions',
+  'Texts.content-solutions-paragraph-1':
+    'CraftScript builds production-ready solutions across Web3, DeFi, AI, and custom software delivery.',
+  'Texts.content-solutions-paragraph-2':
+    'We focus on secure architecture, clean user flows, and maintainable systems that support real business use cases.',
+  'Texts.content-solutions-paragraph-3':
+    'Each project is shaped around measurable outcomes, practical delivery, and technology that can scale.',
+  'Texts.content-ai-integration-title': 'AI integration',
+  'Texts.content-ai-integration-paragraph-1':
+    'We integrate AI into existing products and operational workflows where it can create measurable leverage.',
+  'Texts.content-ai-integration-paragraph-2':
+    'From data pipelines to assistant experiences, we connect models with reliable interfaces and business context.',
+  'Texts.content-ai-integration-paragraph-3':
+    'The focus is useful automation, clear controls, and systems that teams can trust in daily work.',
+  'Texts.content-content-cms-systems-title': 'CMS systems',
+  'Texts.content-content-cms-systems-paragraph-1':
+    'We build content management systems that make publishing, governance, and localization easier for teams.',
+  'Texts.content-content-cms-systems-paragraph-2':
+    'Editorial workflows, structured content, and role-based access help organizations maintain high-quality content.',
+  'Texts.content-content-cms-systems-paragraph-3':
+    'The result is a flexible foundation for websites, applications, and omnichannel digital experiences.',
+  'Texts.content-content-defi-systems-title': 'DeFi systems',
+  'Texts.content-content-defi-systems-paragraph-1':
+    'We create decentralized finance products with clear interfaces, reliable integrations, and thoughtful risk controls.',
+  'Texts.content-content-defi-systems-paragraph-2':
+    'Our work spans lending, trading, asset flows, protocol integrations, and blockchain-backed user experiences.',
+  'Texts.content-content-defi-systems-paragraph-3':
+    'We focus on transparent behavior, maintainable contracts, and product experiences that users can understand.',
+  'Texts.content-content-modularity-systems-title': 'Modularity systems',
+  'Texts.content-content-modularity-systems-paragraph-1':
+    'We design modular software systems that can change without forcing teams to rebuild everything at once.',
+  'Texts.content-content-modularity-systems-paragraph-2':
+    'Composable architecture helps products evolve across teams, integrations, markets, and customer needs.',
+  'Texts.content-content-modularity-systems-paragraph-3':
+    'This keeps delivery practical while preserving room for long-term product growth.',
+  'Texts.content-content-software-processes-title':
+    'Software development processes',
+  'Texts.content-content-software-processes-paragraph-1':
+    'We improve software delivery through clear planning, iterative development, automated checks, and production feedback.',
+  'Texts.content-content-software-processes-paragraph-2':
+    'Strong engineering practices reduce delivery risk and make complex systems easier to maintain.',
+  'Texts.content-content-software-processes-paragraph-3':
+    'Our process keeps product goals, technical quality, and release reliability connected.',
   'Texts.metadata-home-title':
     'CraftScript | Easy discovering of Web3 world together | DeFi and Dex in your hands',
   'Texts.metadata-home-description':

--- a/src/stores/reducers/i18n/reducer.ts
+++ b/src/stores/reducers/i18n/reducer.ts
@@ -4,21 +4,20 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import Cookies from 'js-cookie';
 
 import { ILanguage } from '@src/types/entities/language';
-import { defaultTranslations } from '@src/stores/reducers/i18n/default';
+import {
+  defaultLanguages,
+  defaultTranslations,
+} from '@src/stores/reducers/i18n/default';
+import { DEFAULT_LANGUAGE } from '@src/i18n/locales';
 
-interface II18nState extends ILanguage {
+export interface II18nState extends ILanguage {
   activeLanguage: string;
 }
 
 const initialState: II18nState = {
   translations: defaultTranslations,
-  languages: {
-    EN: {
-      language: 'English',
-      title: 'EN',
-    },
-  },
-  activeLanguage: Cookies.get('active-language') || 'EN',
+  languages: defaultLanguages,
+  activeLanguage: Cookies.get('active-language') || DEFAULT_LANGUAGE,
 };
 
 export const i18nSlice = createSlice({


### PR DESCRIPTION
## Summary
- preload server-side i18n state so localized routes render translated content in initial HTML
- keep localized pages on the single root provider instead of nesting Redux/React Query providers
- add typed Vitest coverage for server i18n, SSR localized HTML, default translation happy path, and missing-key detection
- bump app version to 1.0.6 for the master release gate

## Verification
- pnpm exec eslint --ext .tsx --ext .ts ./ --max-warnings 0
- pnpm run typecheck
- pnpm run format:check
- pnpm test
- GITHUB_BASE_REF=master pnpm run check:release-version